### PR TITLE
fix: 🐛 brew bundleの部分的失敗でセットアップ全体が中断する問題を修正

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -96,8 +96,13 @@ run_brew_bundle() {
     echo "  ..."
   else
     cd "$SCRIPT_DIR"
-    brew bundle --file=Brewfile
-    log_success "Homebrew packages installed"
+    # Allow individual package failures; don't abort the whole setup.
+    if brew bundle --file=Brewfile; then
+      log_success "Homebrew packages installed"
+    else
+      log_warning "Some Homebrew packages failed to install (continuing setup)"
+      log_info "  To retry: ./setup.sh -b"
+    fi
   fi
 }
 


### PR DESCRIPTION
set -eによりbrew bundleの失敗がスクリプト全体を中断していたため、
個別パッケージの失敗を警告として扱い後続ステップを続行するよう変更