### PR TITLE
fix: 🐛 Starship Pythonモジュールのcommand_timeoutを個別設定

### DIFF
--- a/starship.toml
+++ b/starship.toml
@@ -31,6 +31,7 @@ format = "[$symbol($version)]($style) "
 [python]
 symbol = " "
 format = "[$symbol($version)]($style) "
+command_timeout = 2000
 
 [rust]
 symbol = " "


### PR DESCRIPTION
Python起動時間がグローバルタイムアウト(1000ms)を超過する環境での
警告を解消するため、Pythonモジュールにのみcommand_timeout=2000を設定。
他モジュールのプロンプト表示速度には影響しない。