### PR TITLE
nvim設定のLSP・DevContainer・autotag・lintを修正

### DIFF
--- a/nvim/lua/plugins/autotag.lua
+++ b/nvim/lua/plugins/autotag.lua
@@ -6,7 +6,7 @@
 
 return {
   "windwp/nvim-ts-autotag",
-  event = "InsertEnter",
+  event = { "BufReadPre", "BufNewFile" },
   dependencies = {
     "nvim-treesitter/nvim-treesitter",
   },

--- a/nvim/lua/plugins/devcontainer.lua
+++ b/nvim/lua/plugins/devcontainer.lua
@@ -33,21 +33,23 @@ return {
       'DevcontainerDown',
       'DevcontainerConnect',
       'DevcontainerExec',
-      'DevContainerToggle',
-      'DevcontainerLogs',
+      'DevcontainerToggle',
     },
     keys = {
       -- コンテナ基本操作
       { '<leader>Du', '<cmd>DevcontainerUp<CR>', desc = 'DevContainer: ビルド・起動' },
       { '<leader>Dd', '<cmd>DevcontainerDown<CR>', desc = 'DevContainer: 停止・削除' },
-      { '<leader>Dt', '<cmd>DevContainerToggle<CR>', desc = 'DevContainer: ターミナル切替' },
+      { '<leader>Dt', '<cmd>DevcontainerToggle<CR>', desc = 'DevContainer: ターミナル切替' },
 
       -- コンテナ内でシェルを起動（推奨）
       {
         '<leader>Dc',
         function()
           -- コンテナ内でzshを起動（下部に表示）
-          vim.cmd("DevcontainerExec cmd='zsh' direction='horizontal'")
+          vim.api.nvim_cmd({
+            cmd = 'DevcontainerExec',
+            args = { "cmd='zsh' direction='horizontal'" },
+          }, {})
         end,
         desc = 'DevContainer: シェル接続',
       },
@@ -76,7 +78,10 @@ return {
         function()
           vim.ui.input({ prompt = 'Command to execute: ' }, function(cmd)
             if cmd and cmd ~= '' then
-              vim.cmd("DevcontainerExec cmd='" .. cmd .. "'")
+              vim.api.nvim_cmd({
+                cmd = 'DevcontainerExec',
+                args = { cmd },
+              }, {})
             end
           end)
         end,

--- a/nvim/lua/plugins/lint.lua
+++ b/nvim/lua/plugins/lint.lua
@@ -47,11 +47,50 @@ return {
 
     -- 自動リント実行（autocmd）
     local lint_augroup = vim.api.nvim_create_augroup('lint', { clear = true })
+    local heavy_linters_by_ft = {
+      python = { 'mypy' },
+      go = { 'golangcilint' },
+    }
 
-    vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWritePost', 'InsertLeave' }, {
+    local function try_lint(include_heavy)
+      if include_heavy then
+        lint.try_lint()
+        return
+      end
+
+      local linters = lint.linters_by_ft[vim.bo.filetype]
+      if not linters then
+        return
+      end
+
+      local heavy_linters = {}
+      for _, linter in ipairs(heavy_linters_by_ft[vim.bo.filetype] or {}) do
+        heavy_linters[linter] = true
+      end
+
+      local light_linters = {}
+      for _, linter in ipairs(linters) do
+        if not heavy_linters[linter] then
+          table.insert(light_linters, linter)
+        end
+      end
+
+      if #light_linters > 0 then
+        lint.try_lint(light_linters)
+      end
+    end
+
+    vim.api.nvim_create_autocmd({ 'BufEnter', 'InsertLeave' }, {
       group = lint_augroup,
       callback = function()
-        lint.try_lint()
+        try_lint(false)
+      end,
+    })
+
+    vim.api.nvim_create_autocmd('BufWritePost', {
+      group = lint_augroup,
+      callback = function()
+        try_lint(true)
       end,
     })
 
@@ -78,6 +117,6 @@ return {
 -- :LintInfo    - 現在のファイルタイプに設定されたリンター表示
 --
 -- 自動リント:
--- - ファイルを開いた時
--- - ファイル保存後
--- - インサートモード終了時
+-- - ファイルを開いた時（重いリンターを除く）
+-- - インサートモード終了時（重いリンターを除く）
+-- - ファイル保存後（全リンター）

--- a/nvim/lua/plugins/lsp.lua
+++ b/nvim/lua/plugins/lsp.lua
@@ -62,102 +62,97 @@ return {
       -- Capabilities設定（nvim-cmpとの連携）
       local capabilities = require('cmp_nvim_lsp').default_capabilities()
 
-      -- 自動インストール + ハンドラー設定
+      local servers = {
+        -- スクリプト言語
+        'lua_ls',           -- Lua
+        'ts_ls',            -- TypeScript/JavaScript
+        'pyright',          -- Python
+        'intelephense',     -- PHP
+
+        -- コンパイル言語
+        'gopls',            -- Go
+        'rust_analyzer',    -- Rust
+        'clangd',           -- C/C++
+
+        -- Web
+        'html',             -- HTML
+        'cssls',            -- CSS
+        'tailwindcss',      -- Tailwind CSS
+
+        -- データ・設定ファイル
+        'jsonls',           -- JSON
+        'yamlls',           -- YAML
+        'taplo',            -- TOML
+
+        -- シェル・インフラ
+        'bashls',           -- Bash/Zsh
+        'dockerls',         -- Dockerfile
+        'docker_compose_language_service',  -- Docker Compose
+        'terraformls',      -- Terraform
+      }
+
+      -- Neovim 0.11+ のネイティブLSP設定APIを使用
+      for _, server_name in ipairs(servers) do
+        vim.lsp.config(server_name, {
+          capabilities = capabilities,
+        })
+      end
+
+      -- lua_ls専用設定
+      vim.lsp.config('lua_ls', {
+        capabilities = capabilities,
+        settings = {
+          Lua = {
+            diagnostics = {
+              globals = { 'vim' },
+            },
+            workspace = {
+              library = vim.api.nvim_get_runtime_file('', true),
+              checkThirdParty = false,
+            },
+            telemetry = {
+              enable = false,
+            },
+          },
+        },
+      })
+
+      -- ts_ls専用設定
+      vim.lsp.config('ts_ls', {
+        capabilities = capabilities,
+        settings = {
+          typescript = {
+            inlayHints = {
+              includeInlayParameterNameHints = 'all',
+              includeInlayParameterNameHintsWhenArgumentMatchesName = false,
+              includeInlayFunctionParameterTypeHints = true,
+              includeInlayVariableTypeHints = true,
+              includeInlayPropertyDeclarationTypeHints = true,
+              includeInlayFunctionLikeReturnTypeHints = true,
+              includeInlayEnumMemberValueHints = true,
+            },
+          },
+        },
+      })
+
+      -- pyright専用設定
+      vim.lsp.config('pyright', {
+        capabilities = capabilities,
+        settings = {
+          python = {
+            analysis = {
+              typeCheckingMode = 'basic',
+              autoSearchPaths = true,
+              useLibraryCodeForTypes = true,
+            },
+          },
+        },
+      })
+
+      -- 自動インストール + インストール済みサーバーの自動有効化
       require('mason-lspconfig').setup({
-        ensure_installed = {
-          -- スクリプト言語
-          'lua_ls',           -- Lua
-          'ts_ls',            -- TypeScript/JavaScript
-          'pyright',          -- Python
-          'intelephense',     -- PHP
-
-          -- コンパイル言語
-          'gopls',            -- Go
-          'rust_analyzer',    -- Rust
-          'clangd',           -- C/C++
-
-          -- Web
-          'html',             -- HTML
-          'cssls',            -- CSS
-          'tailwindcss',      -- Tailwind CSS
-
-          -- データ・設定ファイル
-          'jsonls',           -- JSON
-          'yamlls',           -- YAML
-          'taplo',            -- TOML
-
-          -- シェル・インフラ
-          'bashls',           -- Bash/Zsh
-          'dockerls',         -- Dockerfile
-          'docker_compose_language_service',  -- Docker Compose
-          'terraformls',      -- Terraform
-        },
-        automatic_installation = true,
-        handlers = {
-          -- デフォルトハンドラー（全サーバー共通）
-          function(server_name)
-            require('lspconfig')[server_name].setup({
-              capabilities = capabilities,
-            })
-          end,
-
-          -- lua_ls専用設定
-          ['lua_ls'] = function()
-            require('lspconfig').lua_ls.setup({
-              capabilities = capabilities,
-              settings = {
-                Lua = {
-                  diagnostics = {
-                    globals = { 'vim' },
-                  },
-                  workspace = {
-                    library = vim.api.nvim_get_runtime_file('', true),
-                    checkThirdParty = false,
-                  },
-                  telemetry = {
-                    enable = false,
-                  },
-                },
-              },
-            })
-          end,
-
-          -- ts_ls専用設定
-          ['ts_ls'] = function()
-            require('lspconfig').ts_ls.setup({
-              capabilities = capabilities,
-              settings = {
-                typescript = {
-                  inlayHints = {
-                    includeInlayParameterNameHints = 'all',
-                    includeInlayParameterNameHintsWhenArgumentMatchesName = false,
-                    includeInlayFunctionParameterTypeHints = true,
-                    includeInlayVariableTypeHints = true,
-                    includeInlayPropertyDeclarationTypeHints = true,
-                    includeInlayFunctionLikeReturnTypeHints = true,
-                    includeInlayEnumMemberValueHints = true,
-                  },
-                },
-              },
-            })
-          end,
-
-          -- pyright専用設定
-          ['pyright'] = function()
-            require('lspconfig').pyright.setup({
-              capabilities = capabilities,
-              settings = {
-                python = {
-                  analysis = {
-                    typeCheckingMode = 'basic',
-                    autoSearchPaths = true,
-                    useLibraryCodeForTypes = true,
-                  },
-                },
-              },
-            })
-          end,
-        },
+        ensure_installed = servers,
+        automatic_enable = true,
       })
 
       -- 診断表示設定


### PR DESCRIPTION
## Summary
- `mason-lspconfig` の現行APIに合わせて LSP 設定を整理し、`lua_ls` などの個別設定が反映されるようにしました。
- Dev Container のコマンド名を実装に合わせて修正し、任意入力の実行も安全に扱うようにしました。
- `nvim-ts-autotag` の読み込みタイミングを見直し、最初の編集から効くようにしました。
- 自動 lint は軽量なものを開いた時・Insert終了時に、重いものは保存時に寄せて負荷を抑えました。

## Testing
- Neovim を headless で起動し、設定の読み込みが成功することを確認しました。
- `lua_ls` の設定登録、`DevcontainerToggle` のコマンド存在、`autotag` のロード、lint の autocmd 分離を確認しました。