### PR TITLE
Claude と Sketchybar 周りの設定不整合と安全性を改善

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -205,7 +205,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.status = \"waiting_confirmation\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.status = \"waiting_confirmation\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
+            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ] && [ \"$AGI_COCKPIT_AGENT_TYPE\" = \"claude\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.agentType = \"claude\" | .status = \"waiting_confirmation\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.agentType = \"claude\" | .status = \"waiting_confirmation\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
           }
         ]
       }
@@ -225,7 +225,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.status = \"running\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.status = \"running\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
+            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ] && [ \"$AGI_COCKPIT_AGENT_TYPE\" = \"claude\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.agentType = \"claude\" | .status = \"running\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.agentType = \"claude\" | .status = \"running\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
           }
         ]
       }
@@ -244,7 +244,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.status = \"waiting_confirmation\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.status = \"waiting_confirmation\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
+            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ] && [ \"$AGI_COCKPIT_AGENT_TYPE\" = \"claude\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.agentType = \"claude\" | .status = \"waiting_confirmation\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.agentType = \"claude\" | .status = \"waiting_confirmation\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
           }
         ]
       }
@@ -263,7 +263,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ]; then INPUT=$(cat); SID=$(printf \"%s\" \"$INPUT\" | jq -r '(.session_id // .sessionId // ((.transcript_path // .transcriptPath // \"\") | split(\"/\") | last | sub(\"\\\\.jsonl$\"; \"\"))) // empty' 2>/dev/null); if [ -z \"$SID\" ]; then SID=$(echo \"$CLAUDE_ENV_FILE\" | sed -n \"s|.*/session-env/\\([^/]*\\)/.*|\\1|p\"); fi; mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq --arg sid \"$SID\" '.status = \"waiting_confirmation\" | .sessionId = $sid' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n --arg sid \"$SID\" '.status = \"waiting_confirmation\" | .sessionId = $sid' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
+            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ] && [ \"$AGI_COCKPIT_AGENT_TYPE\" = \"claude\" ]; then INPUT=$(cat); SID=$(printf \"%s\" \"$INPUT\" | jq -r '(.session_id // .sessionId // ((.transcript_path // .transcriptPath // \"\") | split(\"/\") | last | sub(\"\\\\.jsonl$\"; \"\"))) // empty' 2>/dev/null); if [ -z \"$SID\" ]; then SID=$(echo \"$CLAUDE_ENV_FILE\" | sed -n \"s|.*/session-env/\\([^/]*\\)/.*|\\1|p\"); fi; mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq --arg sid \"$SID\" '.agentType = \"claude\" | .status = \"waiting_confirmation\" | .sessionId = $sid' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n --arg sid \"$SID\" '.agentType = \"claude\" | .status = \"waiting_confirmation\" | .sessionId = $sid' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
           }
         ]
       }
@@ -274,7 +274,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ]; then INPUT=$(cat); SID=$(printf \"%s\" \"$INPUT\" | jq -r '(.session_id // .sessionId // ((.transcript_path // .transcriptPath // \"\") | split(\"/\") | last | sub(\"\\\\.jsonl$\"; \"\"))) // empty' 2>/dev/null); if [ -z \"$SID\" ]; then SID=$(echo \"$CLAUDE_ENV_FILE\" | sed -n \"s|.*/session-env/\\([^/]*\\)/.*|\\1|p\"); fi; mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq --arg sid \"$SID\" '.sessionId = $sid' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n --arg sid \"$SID\" '.sessionId = $sid' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
+            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ] && [ \"$AGI_COCKPIT_AGENT_TYPE\" = \"claude\" ]; then INPUT=$(cat); SID=$(printf \"%s\" \"$INPUT\" | jq -r '(.session_id // .sessionId // ((.transcript_path // .transcriptPath // \"\") | split(\"/\") | last | sub(\"\\\\.jsonl$\"; \"\"))) // empty' 2>/dev/null); if [ -z \"$SID\" ]; then SID=$(echo \"$CLAUDE_ENV_FILE\" | sed -n \"s|.*/session-env/\\([^/]*\\)/.*|\\1|p\"); fi; mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq --arg sid \"$SID\" '.agentType = \"claude\" | .sessionId = $sid' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n --arg sid \"$SID\" '.agentType = \"claude\" | .sessionId = $sid' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
           }
         ]
       }
@@ -285,7 +285,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.status = \"running\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.status = \"running\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
+            "command": "AGI_COCKPIT_HOOK=1; if [ -n \"$AGI_COCKPIT_STATUS_FILE\" ] && [ \"$AGI_COCKPIT_AGENT_TYPE\" = \"claude\" ]; then mkdir -p \"$(dirname \"$AGI_COCKPIT_STATUS_FILE\")\"; TMP=\"${AGI_COCKPIT_STATUS_FILE}.tmp\"; if [ -f \"$AGI_COCKPIT_STATUS_FILE\" ]; then jq  '.agentType = \"claude\" | .status = \"running\"' \"$AGI_COCKPIT_STATUS_FILE\" > \"$TMP\"; else jq -n  '.agentType = \"claude\" | .status = \"running\"' > \"$TMP\"; fi; if [ -s \"$TMP\" ]; then mv \"$TMP\" \"$AGI_COCKPIT_STATUS_FILE\"; else rm -f \"$TMP\"; fi; fi"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gh/
 *.bak
 
 # Neovim
+.nvimlog
 nvim/lua/core/*.backup
 
 # Yazi temporary files

--- a/.nvimlog
+++ b/.nvimlog
@@ -1,1 +1,0 @@
-WRN 2026-05-09T19:50:32.916 ?.41518    server_start:199: Failed to start server: operation not permitted: /var/folders/3c/j_y0060d17b0npf2f2fyhnpr0000gn/T/nvim.nakayamaseiya/CfvIKb/nvim.41518.0

--- a/scripts/deny-check.sh
+++ b/scripts/deny-check.sh
@@ -51,6 +51,10 @@ check_command_part "$command"
 split_command="${command//;/$'\n'}"
 split_command="${split_command//&&/$'\n'}"
 split_command="${split_command//\|\|/$'\n'}"
+split_command="${split_command//|/$'\n'}"
+split_command="${split_command//\$\(/$'\n'}"
+split_command="${split_command//\)/$'\n'}"
+split_command="${split_command//\`/$'\n'}"
 
 while IFS= read -r cmd_part; do
   [ -z "$(printf '%s' "$cmd_part" | tr -d '[:space:]')" ] && continue

--- a/sketchybar/helpers/event_providers/makefile
+++ b/sketchybar/helpers/event_providers/makefile
@@ -1,3 +1,4 @@
 all:
 	(cd cpu_load && $(MAKE))
+	(cd memory_load && $(MAKE))
 	(cd network_load && $(MAKE))

--- a/sketchybar/helpers/shell.lua
+++ b/sketchybar/helpers/shell.lua
@@ -1,0 +1,7 @@
+local M = {}
+
+function M.quote(value)
+	return "'" .. tostring(value):gsub("'", "'\\''") .. "'"
+end
+
+return M

--- a/sketchybar/icon_updater.sh
+++ b/sketchybar/icon_updater.sh
@@ -1,39 +1,28 @@
 #!/usr/bin/env bash
 
-# if tmp_icons exists, remove it
-if [ -d "tmp_icons" ]; then
-  echo "Removing existing tmp_icons directory..."
-  rm -rf tmp_icons
-fi
+set -euo pipefail
 
-git clone https://github.com/SoichiroYamane/sketchybar-app-font-bg tmp_icons
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/sketchybar-icons.XXXXXX")
+repo_dir="$tmp_dir/sketchybar-app-font-bg"
+trap 'rm -rf "$tmp_dir"' EXIT
 
-cd ./tmp_icons || exit
+git clone https://github.com/SoichiroYamane/sketchybar-app-font-bg "$repo_dir"
 
-if pnpm install; then
-  echo "done: pnpm install"
-else
-  echo "pnpm install failed"
-fi
+cd "$repo_dir"
 
-if pnpm run build:install; then
-  echo "done: pnpm run build:install"
-  cd ..
-else
-  echo "pnpm build:install failed"
-  exit 1
-fi
+pnpm install
+echo "done: pnpm install"
+
+pnpm run build:install
+echo "done: pnpm run build:install"
+
+mkdir -p "$HOME/Library/Fonts" "$HOME/.config/sketchybar/helpers"
 
 # replace ttf
-# move ./tmp_icons/public/dist/sketchybar-app-font-bg.ttf to $HOME/Library/Fonts/sketchybar-app-font-bg.ttf
-mv ./tmp_icons/public/dist/sketchybar-app-font-bg.ttf "$HOME/Library/Fonts/sketchybar-app-font-bg.ttf"
+install -m 0644 public/dist/sketchybar-app-font-bg.ttf "$HOME/Library/Fonts/sketchybar-app-font-bg.ttf"
 
 # replace icon_map.lua
-# move ./tmp_icons/public/dist/icon_map.lua to $HOME/.config/sketchybar/helpers/icon_map.lua
-mv ./tmp_icons/public/dist/icon_map.lua "$HOME/.config/sketchybar/helpers/icon_map.lua"
-
-# Cleanup: remove the cloned repository folder
-rm -rf tmp_icons
+install -m 0644 public/dist/icon_map.lua "$HOME/.config/sketchybar/helpers/icon_map.lua"
 
 echo "Font installed successfully to $HOME/Library/Fonts/sketchybar-app-font-bg.ttf"
 

--- a/sketchybar/items/spaces.lua
+++ b/sketchybar/items/spaces.lua
@@ -5,28 +5,65 @@ local app_icons = require("helpers.icon_map")
 
 local spaces = {}
 
--- Aerospace workspaces (1-9, A-G)
-local workspaces = { "1", "2", "3", "4", "5", "6", "7", "8", "9", "A", "B", "C", "D", "E", "F", "G" }
+-- Aerospace workspaces
+local workspaces = {
+	"1",
+	"2",
+	"3",
+	"4",
+	"5",
+	"6",
+	"7",
+	"8",
+	"9",
+	"A",
+	"B",
+	"C",
+	"D",
+	"E",
+	"F",
+	"G",
+	"I",
+	"M",
+	"N",
+	"O",
+	"P",
+	"Q",
+	"R",
+	"S",
+	"T",
+	"U",
+	"V",
+	"W",
+	"X",
+	"Y",
+	"Z",
+}
 
 -- Color mapping for workspaces
-local colors_spaces = {
-	["1"] = colors.cmap_1,
-	["2"] = colors.cmap_2,
-	["3"] = colors.cmap_3,
-	["4"] = colors.cmap_4,
-	["5"] = colors.cmap_5,
-	["6"] = colors.cmap_6,
-	["7"] = colors.cmap_7,
-	["8"] = colors.cmap_8,
-	["9"] = colors.cmap_9,
-	["A"] = colors.cmap_10,
-	["B"] = colors.tn_magenta,
-	["C"] = colors.tn_blue,
-	["D"] = colors.tn_cyan,
-	["E"] = colors.tn_green,
-	["F"] = colors.tn_yellow,
-	["G"] = colors.tn_orange,
+local workspace_palette = {
+	colors.cmap_1,
+	colors.cmap_2,
+	colors.cmap_3,
+	colors.cmap_4,
+	colors.cmap_5,
+	colors.cmap_6,
+	colors.cmap_7,
+	colors.cmap_8,
+	colors.cmap_9,
+	colors.cmap_10,
+	colors.tn_magenta,
+	colors.tn_blue,
+	colors.tn_cyan,
+	colors.tn_green,
+	colors.tn_yellow,
+	colors.tn_orange,
 }
+
+local colors_spaces = {}
+for index, ws_name in ipairs(workspaces) do
+	colors_spaces[ws_name] = workspace_palette[((index - 1) % #workspace_palette) + 1]
+end
 
 -- Register custom event for aerospace workspace change
 sbar.add("event", "aerospace_workspace_change")

--- a/sketchybar/items/widgets/volume.lua
+++ b/sketchybar/items/widgets/volume.lua
@@ -1,6 +1,7 @@
 local colors = require("colors")
 local icons = require("icons")
 local settings = require("settings")
+local shell = require("helpers.shell")
 
 local popup_width = 250
 
@@ -139,9 +140,9 @@ local function volume_toggle_details(env)
 						width = popup_width,
 						align = "center",
 						label = { string = device, color = color },
-						click_script = 'SwitchAudioSource -s "'
-							.. device
-							.. '" && sketchybar --set /volume.device\\.*/ label.color='
+						click_script = "SwitchAudioSource -s "
+							.. shell.quote(device)
+							.. " && sketchybar --set /volume.device\\.*/ label.color="
 							.. colors.grey
 							.. " --set $NAME label.color="
 							.. colors.white,

--- a/sketchybar/items/widgets/wifi.lua
+++ b/sketchybar/items/widgets/wifi.lua
@@ -1,6 +1,7 @@
 local icons = require("icons")
 local colors = require("colors")
 local settings = require("settings")
+local shell = require("helpers.shell")
 
 -- Execute the event provider binary which provides the event "network_update"
 -- for the network interface "en0", which is fired every 2.0 seconds.
@@ -309,7 +310,7 @@ wifi:subscribe("mouse.exited.global", hide_details)
 
 local function copy_label_to_clipboard(env)
 	local label = sbar.query(env.NAME).label.value
-	sbar.exec('echo "' .. label .. '" | pbcopy')
+	sbar.exec("printf %s " .. shell.quote(label) .. " | pbcopy")
 	sbar.set(env.NAME, { label = { string = icons.clipboard, align = "center" } })
 	sbar.delay(1, function()
 		sbar.set(env.NAME, { label = { string = label, align = "right" } })

--- a/tests/test_deny_check.sh
+++ b/tests/test_deny_check.sh
@@ -130,6 +130,9 @@ bold "--- 複合コマンド(;, &&, ||)のチェック ---"
 assert_denied "セミコロン区切りの危険なコマンドを検出" "echo hello; sudo rm -rf /tmp"
 assert_denied "&& 区切りの危険なコマンドを検出" "ls -la && sudo apt update"
 assert_denied "|| 区切りの危険なコマンドを検出" "test -f file || sudo reboot"
+assert_denied "パイプ区切りの危険なコマンドを検出" "echo hello | sudo tee /tmp/hello"
+assert_denied "コマンド置換内の危険なコマンドを検出" "echo \$(sudo whoami)"
+assert_denied "バッククォート内の危険なコマンドを検出" "echo \`sudo whoami\`"
 
 echo ""
 

--- a/tests/test_deny_check.sh
+++ b/tests/test_deny_check.sh
@@ -125,7 +125,7 @@ assert_denied "ssh コマンドは拒否" "ssh user@host"
 echo ""
 
 # --- コマンド分割テスト ---
-bold "--- 複合コマンド(;, &&, ||)のチェック ---"
+bold "--- 複合コマンドのチェック ---"
 
 assert_denied "セミコロン区切りの危険なコマンドを検出" "echo hello; sudo rm -rf /tmp"
 assert_denied "&& 区切りの危険なコマンドを検出" "ls -la && sudo apt update"
@@ -143,7 +143,7 @@ assert_allowed "空のコマンドは許可" ""
 assert_allowed "スペースのみは許可" "   "
 assert_denied "rm -rf /path はワイルドカードで拒否" "rm -rf /tmp/mytest"
 assert_allowed "カレントディレクトリのrm -rfは許可" "rm -rf ./node_modules"
-assert_allowed "パイプは分割しない（安全なコマンド）" "echo hello | grep hello"
+assert_allowed "安全なパイプラインは許可" "echo hello | grep hello"
 
 echo ""
 


### PR DESCRIPTION
## Summary
- `scripts/deny-check.sh` の複合コマンド検出を強化し、パイプやコマンド置換経由の危険な実行も拒否するようにしました
- Sketchybar の memory provider をビルド対象に追加し、Wi-Fi/volume のシェル引数を安全にクォートするようにしました
- `icon_updater.sh` を一時ディレクトリ依存から改善し、失敗時に止まるよう堅牢化しました
- AeroSpace の workspace 定義と Sketchybar の表示を揃え、`.nvimlog` を追跡対象から外しました
- `.claude/settings.json` の Cockpit 状態更新は Claude 実行時のみに限定しました

## Testing
- `tests/test_deny_check.sh` を更新して実行し、拒否・許可の両ケースを確認しました
- Lua 構文チェック、TOML/JSON のパース確認、Sketchybar helper の `make` 実行確認を行いました
- `link.sh -d` の dry-run でリンク構成に問題がないことを確認しました