### PR TITLE
Codex の MCP 起動待ち時間を 120 秒に延長する

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,7 @@
 [mcp_servers.context7]
 command = "npx"
 args = ["-y", "@upstash/context7-mcp@latest"]
+startup_timeout_sec = 120
 
 [mcp_servers.openaiDeveloperDocs]
 url = "https://developers.openai.com/mcp"
@@ -8,6 +9,7 @@ url = "https://developers.openai.com/mcp"
 [mcp_servers.playwright]
 command = "npx"
 args = ["-y", "@playwright/mcp@latest"]
+startup_timeout_sec = 120
 
 [features]
 goals = true

--- a/.codex/user-config.toml.template
+++ b/.codex/user-config.toml.template
@@ -13,6 +13,7 @@ sandbox_mode = "workspace-write"
 [mcp_servers.context7]
 command = "npx"
 args = ["-y", "@upstash/context7-mcp@latest"]
+startup_timeout_sec = 120
 
 [mcp_servers.openaiDeveloperDocs]
 url = "https://developers.openai.com/mcp"
@@ -20,6 +21,7 @@ url = "https://developers.openai.com/mcp"
 [mcp_servers.playwright]
 command = "npx"
 args = ["-y", "@playwright/mcp@latest"]
+startup_timeout_sec = 120
 
 [projects."{{DOTFILE_DIR}}"]
 trust_level = "trusted"


### PR DESCRIPTION
## Summary
- `context7` と `playwright` の MCP 起動タイムアウトを `120` 秒に変更
- 生成元の `.codex/user-config.toml.template` と既存の `.codex/config.toml` を揃えて更新

## Testing
- Not run (not requested)