### PR TITLE
fix: WezTermのURLハイパーリンクを完全に無効化

### DIFF
--- a/wezterm/wezterm.lua
+++ b/wezterm/wezterm.lua
@@ -36,8 +36,8 @@ config.check_for_updates_interval_seconds = 86400
 -- デフォルトの作業ディレクトリをホームディレクトリに設定
 config.default_cwd = wezterm.home_dir
 
--- URLをクリック可能に設定
--- config.hyperlink_rules = wezterm.default_hyperlink_rules()
+-- URLハイパーリンクを無効化（空テーブルでデフォルトルールを上書き）
+config.hyperlink_rules = {}
 
 -- ============================================================================
 -- フォント設定


### PR DESCRIPTION
コメントアウトだけではデフォルトルールが内部で適用され続けるため、
hyperlink_rules = {} で明示的に空テーブルを設定して無効化する。